### PR TITLE
Bucket bug fix

### DIFF
--- a/actor.js
+++ b/actor.js
@@ -36,7 +36,7 @@ class Actor {
     if (level?.currentZoneMap === 2 && !this.grabbed) {
         effectiveBottom = canvasHeight - zoneHeight - inset;
     }
-    //(map with zones at bottom) new boundary to stop buckets from moving past zones.
+    //(map with zones at bottom) new boundary to stop buckets from moving past zones. Otherwise, boundaries stay the same
      if (this.y < 0) { this.y = 0; this.moveAngle = -this.moveAngle; }
      else if (this.y > effectiveBottom - this.height) { this.y = effectiveBottom - this.height; this.moveAngle = -this.moveAngle; }
   }


### PR DESCRIPTION
Prevents buckets from going off-screen after being freed.
Prevents buckets from getting stuck between color zones (specifically for when all zones at bottom of canvas)
Change color of frozen bucket to light-blue to make color more visible.